### PR TITLE
Check service in execute

### DIFF
--- a/drivers/scale_service.go
+++ b/drivers/scale_service.go
@@ -67,6 +67,10 @@ func (s *ScaleServiceDriver) Execute(conf interface{}, apiClient client.RancherC
 		return http.StatusInternalServerError, errors.Wrap(err, "Error in getService")
 	}
 
+	if service == nil || service.Removed != "" {
+		return http.StatusBadRequest, fmt.Errorf("Service %v has been deleted", config.ServiceID)
+	}
+
 	if scaleAction == "up" {
 		newScale = service.Scale + int64(scaleChange)
 	} else if scaleAction == "down" {


### PR DESCRIPTION
Returns BadRequest error from scaleService Execute if service of the webhook has been deleted