### PR TITLE
Add application/json header

### DIFF
--- a/service/routes.go
+++ b/service/routes.go
@@ -19,6 +19,7 @@ func HandleError(s *v1client.Schemas, t func(http.ResponseWriter, *http.Request)
 		if code, err := t(rw, req); err != nil {
 			apiContext := api.GetApiContext(req)
 			logrus.Errorf("Error in request: %v", err)
+			rw.Header().Add("Content-Type", "application/json")
 			rw.WriteHeader(code)
 			writeErr := apiContext.WriteResource(&model.ServerAPIError{
 				Resource: v1client.Resource{


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7443

The API error was of type 'plain/text', changed to 'application/json'
In the webhooks_test I had added condition to check if content-type is application/json wherever API is expected to return an error, but it was already application/json in tests
@cjellick 