### PR TITLE
Allow webhook creation for load balancer

### DIFF
--- a/drivers/scale_service.go
+++ b/drivers/scale_service.go
@@ -53,7 +53,7 @@ func (s *ScaleServiceDriver) ValidatePayload(conf interface{}, apiClient client.
 		return http.StatusBadRequest, fmt.Errorf("Invalid service %v", config.ServiceID)
 	}
 
-	if service.Kind != "service" {
+	if service.Kind != "service" && service.Kind != "loadBalancerService" {
 		return http.StatusBadRequest, fmt.Errorf("Can only create webhooks for Services. The supplied service is of type %v", service.Kind)
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7449

https://github.com/rancher/validation-tests/pull/272 This PR includes validation tests for:
1. Min/max setting
2. Executing webhook whose service has been deleted
3. Creating webhooks for `kind=loadBalancerService` and `kind=externalService`
The third test `test_validate_service_type` https://github.com/rancher/validation-tests/pull/272/files#diff-ea4a835e3cc399810b8f0225ad7130c5R160 will only pass against this PR

@cjellick can you review this?