### PR TITLE
Min cannot be greater than Max

### DIFF
--- a/drivers/scale_service.go
+++ b/drivers/scale_service.go
@@ -44,6 +44,10 @@ func (s *ScaleServiceDriver) ValidatePayload(conf interface{}, apiClient client.
 		return http.StatusBadRequest, fmt.Errorf("Maximum scale not provided/invalid")
 	}
 
+	if config.Min >= config.Max {
+		return http.StatusBadRequest, fmt.Errorf("Max must be greater than min")
+	}
+
 	service, err := apiClient.Service.ById(config.ServiceID)
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrap(err, "Error in getService")


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7446

Didn't add unit test because the ValidatePayload() of the mock driver only checks the values of min, max, action etc against the expectedConfig, and returns 500. So I'll add validation test after the PR: https://github.com/rancher/webhook-service/pull/26 is merged so the validation-test PRs won't clash 
@cjellick 
Also, it's okay to have min=max right?