### PR TITLE
Return exact error from go-rancher client

### DIFF
--- a/drivers/scale_service.go
+++ b/drivers/scale_service.go
@@ -101,7 +101,8 @@ func (s *ScaleServiceDriver) Execute(conf interface{}, apiClient client.RancherC
 		CurrentScale: newScale,
 	})
 	if err != nil {
-		return http.StatusInternalServerError, errors.Wrap(err, "Error in updateService")
+		statusCode := err.(*client.ApiError).StatusCode
+		return statusCode, errors.Wrap(err, "Error in updateService")
 	}
 	return http.StatusOK, nil
 }

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -92,7 +92,7 @@ func (rh *RouteHandler) GetWebhook(w http.ResponseWriter, r *http.Request) (int,
 
 	driver := drivers.GetDriver(webhook.Driver)
 	if driver == nil {
-		return 500, fmt.Errorf("Can't find driver %v", webhook.Driver)
+		return 400, fmt.Errorf("Can't find driver %v", webhook.Driver)
 	}
 
 	respWebhook, err := newWebhook(apiContext, webhook.URL, webhook.ID, webhook.Driver, webhook.Name,
@@ -129,7 +129,8 @@ func (rh *RouteHandler) DeleteWebhook(w http.ResponseWriter, r *http.Request) (i
 
 	err = apiClient.GenericObject.Delete(obj)
 	if err != nil {
-		return 500, err
+		statusCode := err.(*client.ApiError).StatusCode
+		return statusCode, err
 	}
 	return 204, nil
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7469
Deleted/invalid webhooks were returning 404, but the id provided in above bug is 1a1 which is the admin account, so go-rancher client would return 405 (Method not allowed). This PR changes the return code in DeleteWebhook to return exact error. I have also changed return code from UpdateService. One more change: https://github.com/rancher/webhook-service/pull/29/files#diff-6bd475d731186e390d6c5b105abd18c6R95, because I think the user has provided the wrong driver so should get BadRequest in place of 500 error.
I have a test for this ready in validation-test PR, but it will clash with the test for min/max PR, so I will push this test once https://github.com/rancher/webhook-service/pull/27 is merged, is that ok?
@cjellick 