### PR TITLE
Change error code to 400

### DIFF
--- a/service/construct_handler.go
+++ b/service/construct_handler.go
@@ -49,13 +49,13 @@ func (rh *RouteHandler) ConstructPayload(w http.ResponseWriter, r *http.Request)
 		return 400, fmt.Errorf("Driver not provided")
 	}
 
-	driverConfig := getDriverConfig(wh)
-	if driverConfig == nil {
+	driver := drivers.GetDriver(wh.Driver)
+	if driver == nil {
 		return 400, fmt.Errorf("Invalid driver %v", wh.Driver)
 	}
 
-	driver := drivers.GetDriver(wh.Driver)
-	if driver == nil {
+	driverConfig := getDriverConfig(wh)
+	if driverConfig == nil {
 		return 400, fmt.Errorf("Invalid driver %v", wh.Driver)
 	}
 

--- a/service/execute_handler.go
+++ b/service/execute_handler.go
@@ -19,7 +19,7 @@ func (rh *RouteHandler) Execute(w http.ResponseWriter, r *http.Request) (int, er
 	})
 
 	if err != nil || !token.Valid {
-		return 500, err
+		return 400, fmt.Errorf("Invalid token error : %v", err)
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok {

--- a/service/webhooks_test.go
+++ b/service/webhooks_test.go
@@ -286,6 +286,23 @@ func TestWebhookCreateInvalidMinMaxAction(t *testing.T) {
 	}
 }
 
+func TestCreateWithInvalidDriver(t *testing.T) {
+	constructURL := fmt.Sprintf("%s/v1-webhooks/receivers?projectId=1a1", server.URL)
+	jsonStr := []byte(`{"driver":"driverInvalid","name":"wh-name",
+		"scaleServiceConfig": {"serviceId": "id", "amount": 1, "action": "up", "min": -1, "max": 4}}`)
+	request, err := http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler := HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code != 400 {
+		t.Fatalf("Invalid driverservice/execute_handler.go")
+	}
+}
+
 func TestMissingProjectIdHeader(t *testing.T) {
 	constructURL := fmt.Sprintf("%s/v1-webhooks", server.URL)
 	request, err := http.NewRequest("POST", constructURL, bytes.NewBuffer([]byte(`{}`)))


### PR DESCRIPTION
This PR changes invalid token error code to 400.
Also for invalid driver, `getDriverConfig` was being called before `GetDriver` in construct_handler.go, thus resulting in an Internal Server Error 500 in place of 400 error for incorrect driver name provided by user. So this PR changes the order to call GetDriver before getDriverConfig.

Test for invalid token -> https://github.com/rancher/validation-tests/pull/272/files#diff-ea4a835e3cc399810b8f0225ad7130c5R312

@cjellick can you please review?