### PR TITLE
HostScaling group using selectors

### DIFF
--- a/drivers/framework.go
+++ b/drivers/framework.go
@@ -23,6 +23,7 @@ func RegisterDrivers() {
 	Drivers = map[string]WebhookDriver{}
 	Drivers["scaleService"] = &ScaleServiceDriver{}
 	Drivers["serviceUpgrade"] = &ServiceUpgradeDriver{}
+	Drivers["scaleHost"] = &ScaleHostDriver{}
 }
 
 //GetDriver looks up the driver

--- a/drivers/scale_host.go
+++ b/drivers/scale_host.go
@@ -1,0 +1,374 @@
+package drivers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	v1client "github.com/rancher/go-rancher/client"
+	"github.com/rancher/go-rancher/v2"
+	rConfig "github.com/rancher/webhook-service/config"
+	"github.com/rancher/webhook-service/model"
+)
+
+var re = regexp.MustCompile("[0-9]+$")
+
+type ScaleHostDriver struct {
+}
+
+func (s *ScaleHostDriver) ValidatePayload(conf interface{}, apiClient *client.RancherClient) (int, error) {
+	config, ok := conf.(model.ScaleHost)
+	if !ok {
+		return http.StatusInternalServerError, fmt.Errorf("Can't process config")
+	}
+
+	if config.Action == "" {
+		return http.StatusBadRequest, fmt.Errorf("Scale action not provided")
+	}
+
+	if config.Action != "up" && config.Action != "down" {
+		return http.StatusBadRequest, fmt.Errorf("Invalid action %v", config.Action)
+	}
+
+	if config.Amount <= 0 {
+		return http.StatusBadRequest, fmt.Errorf("Invalid amount: %v", config.Amount)
+	}
+
+	if config.HostSelector == nil {
+		return http.StatusBadRequest, fmt.Errorf("HostSelector not provided")
+	}
+
+	if config.Min <= 0 {
+		return http.StatusBadRequest, fmt.Errorf("Minimum scale not provided/invalid")
+	}
+
+	if config.Max <= 0 {
+		return http.StatusBadRequest, fmt.Errorf("Maximum scale not provided/invalid")
+	}
+
+	if config.Min >= config.Max {
+		return http.StatusBadRequest, fmt.Errorf("Max must be greater than min")
+	}
+
+	if config.DeleteOption != "mostRecent" && config.DeleteOption != "leastRecent" {
+		return http.StatusBadRequest, fmt.Errorf("Invalid delete option %v", config.DeleteOption)
+	}
+
+	return http.StatusOK, nil
+}
+
+func (s *ScaleHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, reqBody interface{}) (int, error) {
+	var currNameSuffix, baseHostName, currCloneName, suffix, key, value string
+	var count, index, newHostScale, baseHostIndex int64
+	httpClient := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	config := &model.ScaleHost{}
+	err := mapstructure.Decode(conf, config)
+	if err != nil {
+		return http.StatusInternalServerError, errors.Wrap(err, "Couldn't unmarshal config")
+	}
+
+	action := config.Action
+	amount := config.Amount
+	min := config.Min
+	max := config.Max
+	deleteOption := config.DeleteOption
+
+	hostSelector := make(map[string]string)
+	for key, value = range config.HostSelector {
+		hostSelector[key] = value
+	}
+
+	cattleConfig := rConfig.GetConfig()
+	cattleURL := cattleConfig.CattleURL
+	u, err := url.Parse(cattleURL)
+	if err != nil {
+		panic(err)
+	}
+	cattleURL = strings.Split(cattleURL, u.Path)[0] + "/v2-beta"
+
+	filters := make(map[string]interface{})
+	filters["sort"] = "created"
+	filters["order"] = "desc"
+	hostCollection, err := apiClient.Host.List(&client.ListOpts{
+		Filters: filters,
+	})
+	if len(hostCollection.Data) == 0 {
+		return http.StatusBadRequest, fmt.Errorf("No hosts for scaling found")
+	}
+
+	hostScalingGroup := []client.Host{}
+	hostSelectorPresent := false
+	baseHostIndex = -1
+	for _, host := range hostCollection.Data {
+		labels := host.Labels
+		labelValue, ok := labels[key]
+		if !ok {
+			continue
+		}
+
+		if labelValue != value {
+			continue
+		}
+
+		if host.State == "error" {
+			continue
+		}
+
+		hostSelectorPresent = true
+		hostScalingGroup = append(hostScalingGroup, host)
+
+		if host.Driver != "" {
+			baseHostIndex++
+		}
+	}
+
+	if hostSelectorPresent == false {
+		return http.StatusBadRequest, fmt.Errorf("No host with label %v exists", hostSelector)
+	}
+
+	if baseHostIndex == -1 && action == "up" {
+		return http.StatusBadRequest, fmt.Errorf("Cannot use custom hosts for scaling up")
+	}
+
+	// Consider the least recently created as base host for cloning
+	// Remove domain from host name, scaleHost12.foo.com becomes scaleHost12
+	// Remove largest number suffix from end, scaleHost12 becomes scaleHost
+	// Name has precedence over hostname. If name is set, empty this field for the clones
+	host := hostScalingGroup[baseHostIndex]
+	if host.Name != "" {
+		baseHostName = host.Name
+		host.Name = ""
+	} else {
+		baseHostName = host.Hostname
+	}
+	baseHostName = strings.Split(baseHostName, ".")[0]
+	baseSuffix := re.FindString(baseHostName)
+	basePrefix := strings.TrimRight(baseHostName, baseSuffix)
+
+	// Use raw call to get host so as to get additional driver config
+	getURL := cattleURL + "/projects/" + host.AccountId + "/hosts/" + host.Id
+	hostRaw, err := getHosts(getURL)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	hostCreateURL := cattleURL + "/projects/" + host.AccountId + "/hosts"
+	count = 0
+
+	if action == "up" {
+		newHostScale = amount + int64(len(hostScalingGroup))
+		if newHostScale > max {
+			return http.StatusBadRequest, fmt.Errorf("Cannot scale above provided max scale value")
+		}
+
+		// Get the most recently created host with same prefix as base host, this will have largest suffix
+		suffix = ""
+		for _, currentHost := range hostScalingGroup {
+			if currentHost.Name != "" {
+				currCloneName = currentHost.Name
+			} else {
+				currCloneName = currentHost.Hostname
+			}
+
+			if !strings.Contains(currCloneName, basePrefix) {
+				continue
+			}
+
+			currCloneName = strings.Split(currCloneName, ".")[0]
+			suffix = re.FindString(currCloneName)
+			break
+		}
+
+		// if suffix exists, increment by 1, else append '2' to next clone
+		for count < amount {
+			if suffix != "" {
+				prevNumber, err := strconv.Atoi(suffix)
+				if err != nil {
+					return http.StatusInternalServerError, fmt.Errorf("Error converting %s to int in scaleHost driver: %v", suffix, err)
+				}
+				currNumber := prevNumber + 1
+				currNameSuffix = leftPad(strconv.Itoa(currNumber), "0", len(suffix))
+			} else {
+				currNameSuffix = "2"
+			}
+
+			name := basePrefix + currNameSuffix
+			hostRaw["name"] = ""
+			hostRaw["hostname"] = name
+			labels := make(map[string]interface{})
+			labels[key] = value
+			hostRaw["labels"] = labels
+
+			code, err := createHost(hostRaw, hostCreateURL, httpClient)
+			if err != nil {
+				return code, err
+			}
+
+			suffix = currNameSuffix
+			count++
+		}
+	} else if action == "down" {
+		newHostScale = int64(len(hostScalingGroup)) - amount
+		if newHostScale < min {
+			return http.StatusBadRequest, fmt.Errorf("Cannot scale below provided min scale value")
+		}
+
+		deleteCount := int64(0)
+		for _, host := range hostScalingGroup {
+			state := host.State
+			if state == "inactive" || state == "deactivating" || state == "reconnecting" || state == "disconnected" {
+				deleteHost(host.Id, apiClient)
+				deleteCount++
+			}
+		}
+
+		amount -= deleteCount
+		if deleteOption == "mostRecent" {
+			for count < amount {
+				host = hostScalingGroup[count]
+				code, err := deleteHost(host.Id, apiClient)
+				if err != nil {
+					return code, err
+				}
+				count++
+			}
+		} else if deleteOption == "leastRecent" {
+			for count < amount {
+				index = (int64(len(hostScalingGroup)) - count) - 1
+				host = hostScalingGroup[index]
+				code, err := deleteHost(host.Id, apiClient)
+				if err != nil {
+					return code, err
+				}
+				count++
+			}
+		}
+	}
+
+	return http.StatusOK, nil
+}
+
+func (s *ScaleHostDriver) ConvertToConfigAndSetOnWebhook(conf interface{}, webhook *model.Webhook) error {
+	if scaleConfig, ok := conf.(model.ScaleHost); ok {
+		webhook.ScaleHostConfig = scaleConfig
+		webhook.ScaleHostConfig.Type = webhook.Driver
+		return nil
+	} else if configMap, ok := conf.(map[string]interface{}); ok {
+		config := model.ScaleHost{}
+		err := mapstructure.Decode(configMap, &config)
+		if err != nil {
+			return err
+		}
+		webhook.ScaleHostConfig = config
+		webhook.ScaleHostConfig.Type = webhook.Driver
+		return nil
+	}
+	return fmt.Errorf("Can't convert config %v", conf)
+}
+
+func (s *ScaleHostDriver) GetDriverConfigResource() interface{} {
+	return model.ScaleHost{}
+}
+
+func (s *ScaleHostDriver) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
+	scaleOptions := []string{"up", "down"}
+	deleteOptions := []string{"mostRecent", "leastRecent"}
+	minValue := int64(1)
+
+	action := schema.ResourceFields["action"]
+	action.Type = "enum"
+	action.Options = scaleOptions
+	schema.ResourceFields["action"] = action
+
+	min := schema.ResourceFields["min"]
+	min.Default = 1
+	min.Min = &minValue
+	schema.ResourceFields["min"] = min
+
+	max := schema.ResourceFields["max"]
+	max.Default = 100
+	max.Min = &minValue
+	schema.ResourceFields["max"] = max
+
+	deleteOption := schema.ResourceFields["deleteOption"]
+	deleteOption.Type = "enum"
+	deleteOption.Options = deleteOptions
+	schema.ResourceFields["deleteOption"] = deleteOption
+
+	return schema
+}
+
+func getHosts(hostURL string) (map[string]interface{}, error) {
+	hostsResp := make(map[string]interface{})
+	resp, err := http.Get(hostURL)
+	if err != nil {
+		return nil, err
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(respBytes, &hostsResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return hostsResp, nil
+}
+
+func createHost(host map[string]interface{}, hostCreateURL string, httpClient *http.Client) (int, error) {
+	hostJSON, err := json.Marshal(host)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("Error in JSON marshal of host: %v", err)
+	}
+
+	request, err := http.NewRequest("POST", hostCreateURL, bytes.NewBuffer(hostJSON))
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("Error creating request to create host: %v", err)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	_, err = httpClient.Do(request)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("Error creating host: %v", err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func deleteHost(hostID string, apiClient *client.RancherClient) (int, error) {
+	_, err := apiClient.ExternalHostEvent.Create(&client.ExternalHostEvent{
+		EventType:  "host.evacuate",
+		HostId:     hostID,
+		DeleteHost: true,
+	})
+
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("Error %v in deleting host %s", err, hostID)
+	}
+
+	return http.StatusOK, nil
+}
+
+func leftPad(str, pad string, length int) string {
+	for {
+		if len(str) == length {
+			return str[0:length]
+		}
+		str = pad + str
+	}
+}

--- a/model/driver_model.go
+++ b/model/driver_model.go
@@ -10,6 +10,7 @@ type ScaleService struct {
 	Type        string `json:"type,omitempty" mapstructure:"type"`
 }
 
+//ServiceUpgrade driver
 type ServiceUpgrade struct {
 	ServiceSelector map[string]string `json:"serviceSelector,omitempty" mapstructure:"serviceSelector"`
 	Image           string            `json:"image,omitempty" mapstructure:"image"`
@@ -18,4 +19,15 @@ type ServiceUpgrade struct {
 	IntervalMillis  int64             `json:"intervalMillis,omitempty" mapstructure:"intervalMillis"`
 	StartFirst      bool              `json:"startFirst,omitempty" mapstructure:"startFirst"`
 	Type            string            `json:"type,omitempty" mapstructure:"type"`
+}
+
+//ScaleHost driver
+type ScaleHost struct {
+	HostSelector map[string]string `json:"hostSelector,omitempty" mapstructure:"hostSelector"`
+	Amount       int64             `json:"amount,omitempty" mapstructure:"amount"`
+	Action       string            `json:"action,omitempty" mapstructure:"action"`
+	Min          int64             `json:"min,omitempty" mapstructure:"min"`
+	Max          int64             `json:"max,omitempty" mapstructure:"max"`
+	DeleteOption string            `json:"deleteOption" mapstructure:"deleteOption"`
+	Type         string            `json:"type,omitempty" mapstructure:"type"`
 }

--- a/model/framework_model.go
+++ b/model/framework_model.go
@@ -19,6 +19,7 @@ type Webhook struct {
 	State                string         `json:"state"`
 	ScaleServiceConfig   ScaleService   `json:"scaleServiceConfig"`
 	ServiceUpgradeConfig ServiceUpgrade `json:"serviceUpgradeConfig"`
+	ScaleHostConfig      ScaleHost      `json:"scaleHostConfig"`
 }
 
 type WebhookCollection struct {

--- a/service/framework_test.go
+++ b/service/framework_test.go
@@ -46,6 +46,18 @@ func init() {
 	}
 	drivers.Drivers["serviceUpgrade"] = &MockUpgradeServiceDriver{expectedConfig: expectedUpgradeServiceConfig}
 
+	HostSelector := make(map[string]string)
+	HostSelector["foo"] = "bar"
+	expectedHostConfig := model.ScaleHost{
+		Action:       "up",
+		Amount:       1,
+		HostSelector: HostSelector,
+		Min:          1,
+		Max:          4,
+		DeleteOption: "mostRecent",
+	}
+	drivers.Drivers["scaleHost"] = &MockHostDriver{expectedConfig: expectedHostConfig}
+
 	privateKey := util.ParsePrivateKey("../testutils/private.pem")
 	publicKey := util.ParsePublicKey("../testutils/public.pem")
 	r = &RouteHandler{

--- a/service/scale_host_test.go
+++ b/service/scale_host_test.go
@@ -1,0 +1,319 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mitchellh/mapstructure"
+	v1client "github.com/rancher/go-rancher/client"
+	"github.com/rancher/go-rancher/v2"
+	"github.com/rancher/webhook-service/drivers"
+	"github.com/rancher/webhook-service/model"
+)
+
+func TestWebhookCreateAndExecuteScaleHost(t *testing.T) {
+	label := make(map[string]string)
+	label["foo"] = "bar"
+	// Test creating a webhook
+	constructURL := fmt.Sprintf("%s/v1-webhooks/receivers?projectId=1a1", server.URL)
+	jsonStr := []byte(`{"driver":"scaleHost","name":"wh-name",
+		"scaleHostConfig": {"hostSelector": {"foo": "bar"}, "amount": 1, "action": "up", "min": 1, "max": 4, "deleteOption": "mostRecent"}}`)
+	request, err := http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler := HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code != 200 {
+		t.Fatalf("StatusCode %d means ConstructPayloadTest failed", response.Code)
+	}
+	resp, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wh := &model.Webhook{}
+	err = json.Unmarshal(resp, wh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wh.Name != "wh-name" || wh.Driver != "scaleHost" || wh.Id != "1" || wh.URL == "" || wh.ScaleHostConfig.HostSelector["foo"] != label["foo"] ||
+		wh.ScaleHostConfig.Action != "up" || wh.ScaleHostConfig.Amount != 1 || wh.ScaleHostConfig.Min != 1 ||
+		wh.ScaleHostConfig.Max != 4 || wh.ScaleHostConfig.Type != "scaleHost" {
+		t.Fatalf("Unexpected webhook: %#v", wh)
+	}
+	if !strings.HasSuffix(wh.Links["self"], "/v1-webhooks/receivers/1?projectId=1a1") {
+		t.Fatalf("Bad self URL: %v", wh.Links["self"])
+	}
+
+	// Test getting the created webhook by id
+	byID := fmt.Sprintf("%s/v1-webhooks/receivers/1?projectId=1a1", server.URL)
+	request, err = http.NewRequest("GET", byID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != 200 {
+		t.Fatalf("StatusCode %d means get failed", response.Code)
+	}
+	resp, err = ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wh = &model.Webhook{}
+	err = json.Unmarshal(resp, wh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wh.Name != "wh-name" || wh.Driver != "scaleHost" || wh.Id != "1" || wh.URL == "" || wh.ScaleHostConfig.HostSelector["foo"] != label["foo"] ||
+		wh.ScaleHostConfig.Action != "up" || wh.ScaleHostConfig.Amount != 1 || wh.ScaleHostConfig.Min != 1 ||
+		wh.ScaleHostConfig.Max != 4 || wh.ScaleHostConfig.Type != "scaleHost" {
+		t.Fatalf("Unexpected webhook: %#v", wh)
+	}
+	if !strings.HasSuffix(wh.Links["self"], "/v1-webhooks/receivers/1?projectId=1a1") {
+		t.Fatalf("Bad self URL: %v", wh.Links["self"])
+	}
+
+	// Test executing the webhook
+	url := wh.URL
+	requestExecute, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response = httptest.NewRecorder()
+	handler = HandleError(schemas, r.Execute)
+	handler.ServeHTTP(response, requestExecute)
+	if response.Code != 200 {
+		t.Errorf("StatusCode %d means execute failed", response.Code)
+	}
+
+	//List webhooks
+	requestList, err := http.NewRequest("GET", constructURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestList.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, requestList)
+	if response.Code != 200 {
+		t.Fatalf("StatusCode %d means get failed", response.Code)
+	}
+	resp, err = ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	whCollection := &model.WebhookCollection{}
+	err = json.Unmarshal(resp, whCollection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(whCollection.Data) != 1 {
+		t.Fatal("Added webhook not listed")
+	}
+	wh = &whCollection.Data[0]
+	if wh.Name != "wh-name" || wh.Driver != "scaleHost" || wh.Id != "1" || wh.URL == "" || wh.ScaleHostConfig.HostSelector["foo"] != label["foo"] ||
+		wh.ScaleHostConfig.Action != "up" || wh.ScaleHostConfig.Amount != 1 || wh.ScaleHostConfig.Min != 1 ||
+		wh.ScaleHostConfig.Max != 4 || wh.ScaleHostConfig.Type != "scaleHost" {
+		t.Fatalf("Unexpected webhook: %#v", wh)
+	}
+	if !strings.HasSuffix(wh.Links["self"], "/v1-webhooks/receivers/1?projectId=1a1") {
+		t.Fatalf("Bad self URL: %v", wh.Links["self"])
+	}
+
+	//Delete
+	request, err = http.NewRequest("DELETE", byID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != 204 {
+		t.Fatalf("StatusCode %d means delete failed", response.Code)
+	}
+}
+
+func TestWebhookCreateInvalidMinMaxActionScaleHost(t *testing.T) {
+	constructURL := fmt.Sprintf("%s/v1-webhooks/receivers?projectId=1a1", server.URL)
+	jsonStr := []byte(`{"driver":"scaleHost","name":"wh-name",
+		"scaleHostConfig": {"hostSelector": {"foo": "bar"}, "amount": 1, "action": "up", "min": -1, "max": 4, "deleteOption": "mostRecent"}}`)
+	request, err := http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler := HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code == 200 {
+		t.Fatalf("Invalid min")
+	}
+
+	jsonStr = []byte(`{"driver":"scaleHost","name":"wh-name",
+		"scaleHostConfig": {"hostSelector": {"foo": "bar"}, "amount": 1, "action": "up", "min": 1, "max": -4, "deleteOption": "mostRecent"}}`)
+	request, err = http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	handler = HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code == 200 {
+		t.Fatalf("Invalid max")
+	}
+
+	jsonStr = []byte(`{"driver":"scaleHost","name":"wh-name",
+		"scaleHostConfig": {"hostSelector": {"foo": "bar"}, "amount": 1.5, "action": "up", "min": 1, "max": 4, "deleteOption": "mostRecent"}}`)
+	request, err = http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	handler = HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code != 400 {
+		t.Fatalf("Amount of type float is invalid")
+	}
+
+	jsonStr = []byte(`{"driver":"scaleHost","name":"wh-name",
+		"scaleHostConfig": {"hostSelector": {"foo": "bar"}, "amount": 1, "action": "up", "min": 1.5, "max": 4, "deleteOption": "mostRecent"}}`)
+	request, err = http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	handler = HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code != 400 {
+		t.Fatalf("Min of type float is invalid")
+	}
+
+	jsonStr = []byte(`{"driver":"scaleHost","name":"wh-name",
+		"scaleHostConfig": {"hostSelector": {"foo": "bar"}, "amount": 1, "action": "up", "min": 1, "max": 4.5, "deleteOption": "mostRecent"}}`)
+	request, err = http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	handler = HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code != 400 {
+		t.Fatalf("Max of type float is invalid")
+	}
+
+	jsonStr = []byte(`{"driver":"scaleHost","name":"wh-name",
+		"scaleHostConfig": {"hostSelector": {"foo": "bar"}, "amount": 1, "action": "up", "min": 1, "max": 4, "deleteOption": "random"}}`)
+	request, err = http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	handler = HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code != 400 {
+		t.Fatalf("Invalid delete option")
+	}
+
+	jsonStr = []byte(`{"driver":"scaleHost","name":"wh-name",
+		"scaleHostConfig": {"hostSelector": {"foo": "bar"}, "amount": 1, "action": "random", "min": 1, "max": 4, "deleteOption": "mostRecent"}}`)
+	request, err = http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	handler = HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code != 400 {
+		t.Fatalf("Invalid action")
+	}
+}
+
+type MockHostDriver struct {
+	expectedConfig model.ScaleHost
+}
+
+func (s *MockHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, reqbody interface{}) (int, error) {
+	config := &model.ScaleHost{}
+	err := mapstructure.Decode(conf, config)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("Couldn't unmarshal config: %v", err)
+	}
+
+	if config.HostSelector["foo"] != s.expectedConfig.HostSelector["foo"] {
+		return 500, fmt.Errorf("HostSelector. Expected %v, Actual %v", s.expectedConfig.HostSelector, config.HostSelector)
+	}
+
+	if config.Action != s.expectedConfig.Action {
+		return 500, fmt.Errorf("Action. Expected %v, Actual %v", s.expectedConfig.Action, config.Action)
+	}
+
+	if config.Amount != s.expectedConfig.Amount {
+		return 500, fmt.Errorf("Amount. Expected %v, Actual %v", s.expectedConfig.Amount, config.Amount)
+	}
+
+	logrus.Infof("Execute of mock scale host driver")
+	return 0, nil
+}
+
+func (s *MockHostDriver) ValidatePayload(conf interface{}, apiClient *client.RancherClient) (int, error) {
+	config, ok := conf.(model.ScaleHost)
+	if !ok {
+		return http.StatusInternalServerError, fmt.Errorf("Can't process config")
+	}
+
+	if config.Action != s.expectedConfig.Action {
+		return 400, fmt.Errorf("Action. Expected %v, Actual %v", s.expectedConfig.Action, config.Action)
+	}
+
+	if config.Amount != s.expectedConfig.Amount {
+		return 500, fmt.Errorf("Amount. Expected %v, Actual %v", s.expectedConfig.Amount, config.Amount)
+	}
+
+	if config.Min != s.expectedConfig.Min {
+		return 500, fmt.Errorf("Min. Expected %v, Actual %v", s.expectedConfig.Min, config.Min)
+	}
+
+	if config.Max != s.expectedConfig.Max {
+		return 500, fmt.Errorf("Max. Expected %v, Actual %v", s.expectedConfig.Max, config.Max)
+	}
+
+	if config.DeleteOption != s.expectedConfig.DeleteOption {
+		return 400, fmt.Errorf("Delete option. Expected %v, Actual %v", s.expectedConfig.DeleteOption, config.DeleteOption)
+	}
+
+	if config.HostSelector["foo"] != s.expectedConfig.HostSelector["foo"] {
+		return 500, fmt.Errorf("Selector Label. Expected %v, Actual %v", s.expectedConfig.HostSelector, config.HostSelector)
+	}
+
+	logrus.Infof("Validate payload of mock scale host driver")
+	return 0, nil
+}
+
+func (s *MockHostDriver) GetDriverConfigResource() interface{} {
+	return model.ScaleHost{}
+}
+
+func (s *MockHostDriver) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
+	return schema
+}
+
+func (s *MockHostDriver) ConvertToConfigAndSetOnWebhook(conf interface{}, webhook *model.Webhook) error {
+	ss := &drivers.ScaleHostDriver{}
+	return ss.ConvertToConfigAndSetOnWebhook(conf, webhook)
+}


### PR DESCRIPTION
Host scaling using selectors.
1. Create a host say `dev1` and add a unique label to it `foo=bar`.
All hosts with label `foo=bar` will fall under the same HostScalingGroup. While adding new hosts, one of the hosts with this label will be used for cloning
2. Create a webhook to scale hosts from scaling group with label `foo=bar`. 
3. In Execute, get all hosts sorted in descending order of created time. Find all hosts with label `foo=bar`. Number of such hosts is the length of the HostScalingGroup. If scaling up, consider the least recently created host with that label as the base host. Then from the HostScalingGroup, find the first host (most recently created) that matches base host prefix. Since it is the most recently created one, use its suffix to calculate suffix for the next clone host. Add the selector label `foo=bar` to this clone. Create as many clones as specified by the amount.
4. If scaling down, among all hosts sorted by created time, get the `amount` number of most recently or least recently created hosts (whichever option is given in the webhook), and deactivate and delete them.

Why selector labels would help:
1. If we use a host ID to create webhook, and accidentally delete this host, then no webhooks for it will work. But using a label, we can keep using the webhooks without any restrictions on which hosts to delete, since we won't allow scaling below 1 for any group.
2. All hosts with the label fall in same group. So if I have host `dev1` and its clones, and I manually created some host say `dev12`, which I don't want to get deleted, then since `dev12` won't have the selector label, it will be excluded from the group and not get affected.
3. This also separates different scaling groups.

@cjellick validation tests -> https://github.com/rancher/validation-tests/pull/281/files