### PR TITLE
Remove headers from error

### DIFF
--- a/service/routes.go
+++ b/service/routes.go
@@ -19,7 +19,6 @@ func HandleError(s *v1client.Schemas, t func(http.ResponseWriter, *http.Request)
 		if code, err := t(rw, req); err != nil {
 			apiContext := api.GetApiContext(req)
 			logrus.Errorf("Error in request: %v", err)
-			rw.Header().Add("Content-Type", "application/json")
 			rw.WriteHeader(code)
 			writeErr := apiContext.WriteResource(&model.ServerAPIError{
 				Resource: v1client.Resource{
@@ -33,7 +32,9 @@ func HandleError(s *v1client.Schemas, t func(http.ResponseWriter, *http.Request)
 				logrus.Errorf("Failed to write err: %v", err)
 			}
 		} else {
-			rw.WriteHeader(code)
+			if code != 200 {
+				rw.WriteHeader(code)
+			}
 		}
 	}))
 }


### PR DESCRIPTION
Webhook-service was returning errors with header for content-type, which was causing go-rancher to call `HtmlWriter` in place of `JsonWriter`. So removing the header makes sure it is handled as json.

There were `http: multiple response.WriteHeader calls` messages in logs. Because in case of no error, the HandleError function was first writing the response code, which is not required in case of `200` code hence causing multiple WriteHeader calls