### PR TITLE
Scaling down multiple

### DIFF
--- a/drivers/scale_host.go
+++ b/drivers/scale_host.go
@@ -266,6 +266,7 @@ func (s *ScaleHostDriver) Execute(conf interface{}, apiClient *client.RancherCli
 				if err != nil {
 					return code, err
 				}
+				delIndex++
 				count++
 			}
 		} else if deleteOption == "leastRecent" {
@@ -282,6 +283,7 @@ func (s *ScaleHostDriver) Execute(conf interface{}, apiClient *client.RancherCli
 				if err != nil {
 					return code, err
 				}
+				delIndex++
 				count++
 			}
 		}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7978
I had come across a bug which would delete same host if in bad state twice. That bug was fixed by this PR https://github.com/rancher/webhook-service/pull/40. But I hadn't checked after this fix was in whether normal deletion was working.
The index for hostScalingGroup array was not getting incremented correctly, this PR fixes that.