### PR TITLE
add Alibaba Cloud Docker Hub webhook support in service upgrade

### DIFF
--- a/drivers/service_upgrade.go
+++ b/drivers/service_upgrade.go
@@ -60,7 +60,7 @@ func (s *ServiceUpgradeDriver) Execute(conf interface{}, apiClient *client.Ranch
 
 	requestedTag := config.Tag
 	if requestPayload == nil {
-		return http.StatusBadRequest, fmt.Errorf("No Payload recevied from Docker Hub webhook")
+		return http.StatusBadRequest, fmt.Errorf("No Payload recevied from webhook")
 	}
 
 	requestBody, ok := requestPayload.(map[string]interface{})
@@ -70,25 +70,38 @@ func (s *ServiceUpgradeDriver) Execute(conf interface{}, apiClient *client.Ranch
 
 	pushedData, ok := requestBody["push_data"]
 	if !ok {
-		return http.StatusBadRequest, fmt.Errorf("Incomplete Docker Hub webhook response provided")
+		return http.StatusBadRequest, fmt.Errorf("Incomplete webhook response provided")
 	}
 
 	pushedTag, ok := pushedData.(map[string]interface{})["tag"].(string)
 	if !ok {
-		return http.StatusBadRequest, fmt.Errorf("Docker Hub webhook response contains no tag")
+		return http.StatusBadRequest, fmt.Errorf("Webhook response contains no tag")
 	}
 
 	repository, ok := requestBody["repository"]
 	if !ok {
-		return http.StatusBadRequest, fmt.Errorf("Docker Hub response provided without repository information")
+		return http.StatusBadRequest, fmt.Errorf("Response provided without repository information")
 	}
 
-	imageName, ok := repository.(map[string]interface{})["repo_name"].(string)
-	if !ok {
-		return http.StatusBadRequest, fmt.Errorf("Docker Hub response provided without image name")
+	pushedImage := ""
+	switch config.PayloadFormat {
+	case "alicloud":
+		alicloudFullName, fullnameOk := repository.(map[string]interface{})["repo_full_name"].(string)
+		alicloudRegion, regionOk := repository.(map[string]interface{})["region"].(string)
+		if fullnameOk && regionOk {
+			imageName := "registry." + alicloudRegion + ".aliyuncs.com/" + alicloudFullName
+			pushedImage = imageName + ":" + pushedTag
+		} else {
+			return http.StatusBadRequest, fmt.Errorf("Alicloud Docker Hub response provided without image name")
+		}
+	default:
+		imageName, ok := repository.(map[string]interface{})["repo_name"].(string)
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Response provided without image name")
+		}
+		pushedImage = imageName + ":" + pushedTag
 	}
 
-	pushedImage := imageName + ":" + pushedTag
 	if requestedTag != pushedTag {
 		return http.StatusOK, nil
 	}
@@ -219,7 +232,14 @@ func (s *ServiceUpgradeDriver) GetDriverConfigResource() interface{} {
 }
 
 func (s *ServiceUpgradeDriver) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
+	options := []string{"dockerhub", "alicloud"}
 	minValue := int64(1)
+
+	payloadFormat := schema.ResourceFields["payloadFormat"]
+	payloadFormat.Type = "enum"
+	payloadFormat.Options = options
+	payloadFormat.Default = options[0]
+	schema.ResourceFields["payloadFormat"] = payloadFormat
 
 	batchSize := schema.ResourceFields["batchSize"]
 	batchSize.Default = 1

--- a/model/driver_model.go
+++ b/model/driver_model.go
@@ -14,6 +14,7 @@ type ScaleService struct {
 type ServiceUpgrade struct {
 	ServiceSelector map[string]string `json:"serviceSelector,omitempty" mapstructure:"serviceSelector"`
 	Tag             string            `json:"tag,omitempty" mapstructure:"tag"`
+	PayloadFormat   string            `json:"payloadFormat,omitempty" mapstructure:"payloadFormat"`
 	BatchSize       int64             `json:"batchSize,omitempty" mapstructure:"batchSize"`
 	IntervalMillis  int64             `json:"intervalMillis,omitempty" mapstructure:"intervalMillis"`
 	StartFirst      bool              `json:"startFirst,omitempty" mapstructure:"startFirst"`


### PR DESCRIPTION
payload of Alibaba Cloud Docker Hub's webhook is slightly different from Docker Hub.
So I have added an option in UI for it [#9175](https://github.com/rancher/rancher/issues/9175)
PR for UI change is [here](https://github.com/rancher/ui/pull/1241)
![image](https://user-images.githubusercontent.com/21168270/29991798-4954fc68-8fc0-11e7-895e-cbbf6b8b87e2.png)

![image](https://user-images.githubusercontent.com/21168270/29991802-5974fa9e-8fc0-11e7-9dd0-507df08d4f88.png)
