### PR TITLE
Add a new webhook driver `serviceWebhook`

### DIFF
--- a/drivers/framework.go
+++ b/drivers/framework.go
@@ -12,7 +12,7 @@ var Drivers map[string]WebhookDriver
 //WebhookDriver interface for all drivers
 type WebhookDriver interface {
 	ValidatePayload(config interface{}, apiClient *client.RancherClient) (int, error)
-	Execute(config interface{}, apiClient *client.RancherClient, requestBody interface{}) (int, error)
+	Execute(config interface{}, apiClient *client.RancherClient, requestBody interface{}, requestHeader interface{}) (int, error)
 	GetDriverConfigResource() interface{}
 	ConvertToConfigAndSetOnWebhook(conf interface{}, webhook *model.Webhook) error
 	CustomizeSchema(schema *v1client.Schema) *v1client.Schema
@@ -24,6 +24,7 @@ func RegisterDrivers() {
 	Drivers["scaleService"] = &ScaleServiceDriver{}
 	Drivers["serviceUpgrade"] = &ServiceUpgradeDriver{}
 	Drivers["scaleHost"] = &ScaleHostDriver{}
+	Drivers["serviceWebhook"] = &ServiceWebhookDriver{}
 }
 
 //GetDriver looks up the driver

--- a/drivers/framework.go
+++ b/drivers/framework.go
@@ -12,7 +12,7 @@ var Drivers map[string]WebhookDriver
 //WebhookDriver interface for all drivers
 type WebhookDriver interface {
 	ValidatePayload(config interface{}, apiClient *client.RancherClient) (int, error)
-	Execute(config interface{}, apiClient *client.RancherClient, requestBody interface{}, requestHeader interface{}) (int, error)
+	Execute(config interface{}, apiClient *client.RancherClient, requestBody interface{}, request interface{}) (int, error)
 	GetDriverConfigResource() interface{}
 	ConvertToConfigAndSetOnWebhook(conf interface{}, webhook *model.Webhook) error
 	CustomizeSchema(schema *v1client.Schema) *v1client.Schema

--- a/drivers/framework.go
+++ b/drivers/framework.go
@@ -12,7 +12,7 @@ var Drivers map[string]WebhookDriver
 //WebhookDriver interface for all drivers
 type WebhookDriver interface {
 	ValidatePayload(config interface{}, apiClient *client.RancherClient) (int, error)
-	Execute(config interface{}, apiClient *client.RancherClient, requestBody interface{}, request interface{}) (int, error)
+	Execute(config interface{}, apiClient *client.RancherClient, request interface{}) (int, error)
 	GetDriverConfigResource() interface{}
 	ConvertToConfigAndSetOnWebhook(conf interface{}, webhook *model.Webhook) error
 	CustomizeSchema(schema *v1client.Schema) *v1client.Schema

--- a/drivers/scale_host.go
+++ b/drivers/scale_host.go
@@ -86,7 +86,7 @@ func (s *ScaleHostDriver) ValidatePayload(conf interface{}, apiClient *client.Ra
 	return http.StatusOK, nil
 }
 
-func (s *ScaleHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, reqBody interface{}) (int, error) {
+func (s *ScaleHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, reqBody interface{}, _ interface{}) (int, error) {
 	var currNameSuffix, baseHostName, currCloneName, suffix, key, value string
 	var count, newHostScale, baseHostIndex int64
 

--- a/drivers/scale_host.go
+++ b/drivers/scale_host.go
@@ -86,7 +86,7 @@ func (s *ScaleHostDriver) ValidatePayload(conf interface{}, apiClient *client.Ra
 	return http.StatusOK, nil
 }
 
-func (s *ScaleHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, reqBody interface{}, _ interface{}) (int, error) {
+func (s *ScaleHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, request interface{}) (int, error) {
 	var currNameSuffix, baseHostName, currCloneName, suffix, key, value string
 	var count, newHostScale, baseHostIndex int64
 

--- a/drivers/scale_service.go
+++ b/drivers/scale_service.go
@@ -74,7 +74,7 @@ func (s *ScaleServiceDriver) ValidatePayload(conf interface{}, apiClient *client
 	return http.StatusOK, nil
 }
 
-func (s *ScaleServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, requestBody interface{}) (int, error) {
+func (s *ScaleServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, requestBody interface{}, _ interface{}) (int, error) {
 	config := &model.ScaleService{}
 	err := mapstructure.Decode(conf, config)
 	if err != nil {

--- a/drivers/scale_service.go
+++ b/drivers/scale_service.go
@@ -74,7 +74,7 @@ func (s *ScaleServiceDriver) ValidatePayload(conf interface{}, apiClient *client
 	return http.StatusOK, nil
 }
 
-func (s *ScaleServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, requestBody interface{}, _ interface{}) (int, error) {
+func (s *ScaleServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, request interface{}) (int, error) {
 	config := &model.ScaleService{}
 	err := mapstructure.Decode(conf, config)
 	if err != nil {

--- a/drivers/service_upgrade.go
+++ b/drivers/service_upgrade.go
@@ -50,7 +50,7 @@ func (s *ServiceUpgradeDriver) ValidatePayload(conf interface{}, apiClient *clie
 	return http.StatusOK, nil
 }
 
-func (s *ServiceUpgradeDriver) Execute(conf interface{}, apiClient *client.RancherClient, requestPayload interface{}) (int, error) {
+func (s *ServiceUpgradeDriver) Execute(conf interface{}, apiClient *client.RancherClient, requestPayload interface{}, _ interface{}) (int, error) {
 	requestBody := make(map[string]interface{})
 	config := &model.ServiceUpgrade{}
 	err := mapstructure.Decode(conf, config)

--- a/drivers/service_webhook.go
+++ b/drivers/service_webhook.go
@@ -1,0 +1,98 @@
+package drivers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	// log "github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	// "github.com/pkg/errors"
+	v1client "github.com/rancher/go-rancher/client"
+	"github.com/rancher/go-rancher/v2"
+	"github.com/rancher/webhook-service/model"
+)
+
+type ServiceWebhookDriver struct {
+}
+
+func (s *ServiceWebhookDriver) ValidatePayload(conf interface{}, apiClient *client.RancherClient) (int, error) {
+	_, ok := conf.(model.ServiceWebhook)
+	log.Infof("create Valid")
+	if !ok {
+		return http.StatusInternalServerError, fmt.Errorf("Can't process config")
+	}
+	return http.StatusOK, nil
+}
+
+func (s *ServiceWebhookDriver) Execute(conf interface{}, apiClient *client.RancherClient, requestPayload interface{}, requestHeader interface{}) (int, error) {
+	config := &model.ServiceWebhook{}
+	err := mapstructure.Decode(conf, config)
+	if err != nil {
+		return http.StatusInternalServerError, errors.Wrap(err, "Couldn't unmarshal config")
+	}
+	requestBody, err := json.Marshal(requestPayload)
+	if err != nil {
+		return http.StatusBadRequest, fmt.Errorf("Body should be of type map[string]interface{}")
+	}
+	requestHead := requestHeader.(http.Header)
+	request, err := http.NewRequest("POST", config.ServiceURL, bytes.NewBuffer(requestBody))
+	if err != nil {
+		log.Errorf("fail:%v", err)
+		return 500, err
+	}
+	client := &http.Client{}
+	request.Header = requestHead
+	rep, err := client.Do(request)
+	if err != nil {
+		log.Errorf("fail:%v", err)
+		return 500, err
+	}
+
+	log.Infof("_____Excute paylod %v, ____", requestHead)
+	log.Infof("_____Excute paylod %v, ____", requestBody)
+	log.Infof("Excute config %v", config)
+
+	if rep.StatusCode != 200 {
+		respBody, err := ioutil.ReadAll(rep.Body)
+		if err != nil {
+			log.Errorf("get response from service error:%v", err)
+			return 500, err
+		}
+
+		return rep.StatusCode, errors.New(string(respBody))
+	}
+
+	defer rep.Body.Close()
+	return 200, nil
+}
+
+func (s *ServiceWebhookDriver) ConvertToConfigAndSetOnWebhook(conf interface{}, webhook *model.Webhook) error {
+	if upgradeConfig, ok := conf.(model.ServiceWebhook); ok {
+		webhook.ServiceWebhookConfig = upgradeConfig
+		webhook.ServiceWebhookConfig.Type = webhook.Driver
+		return nil
+	} else if configMap, ok := conf.(map[string]interface{}); ok {
+		config := model.ServiceWebhook{}
+		err := mapstructure.Decode(configMap, &config)
+		if err != nil {
+			return err
+		}
+		webhook.ServiceWebhookConfig = config
+		webhook.ServiceWebhookConfig.Type = webhook.Driver
+		return nil
+	}
+	return fmt.Errorf("Can't convert config %v", conf)
+}
+
+func (s *ServiceWebhookDriver) GetDriverConfigResource() interface{} {
+	return model.ServiceWebhook{}
+}
+
+func (s *ServiceWebhookDriver) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
+	return schema
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/Sirupsen/logrus"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/webhook-service/drivers"
 	"github.com/rancher/webhook-service/service"
@@ -14,6 +16,7 @@ import (
 var VERSION = "v0.0.0-dev"
 
 func main() {
+	logrus.SetLevel(logrus.DebugLevel)
 	app := cli.NewApp()
 	app.Name = "webhook-service"
 	app.Version = VERSION

--- a/model/driver_model.go
+++ b/model/driver_model.go
@@ -31,3 +31,8 @@ type ScaleHost struct {
 	DeleteOption   string            `json:"deleteOption,omitempty" mapstructure:"deleteOption"`
 	Type           string            `json:"type,omitempty" mapstructure:"type"`
 }
+
+type ServiceWebhook struct {
+	ServiceURL string `json:"serviceURL,omitempty" mapstructure:"serviceURL"`
+	Type       string `json:"type,omitempty" mapstructure:"type"`
+}

--- a/model/framework_model.go
+++ b/model/framework_model.go
@@ -20,6 +20,7 @@ type Webhook struct {
 	ScaleServiceConfig   ScaleService   `json:"scaleServiceConfig"`
 	ServiceUpgradeConfig ServiceUpgrade `json:"serviceUpgradeConfig"`
 	ScaleHostConfig      ScaleHost      `json:"scaleHostConfig"`
+	ServiceWebhookConfig ServiceWebhook `json:"serviceWebhookConfig"`
 }
 
 type WebhookCollection struct {

--- a/service/execute_handler.go
+++ b/service/execute_handler.go
@@ -1,9 +1,7 @@
 package service
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -12,31 +10,16 @@ import (
 )
 
 func (rh *RouteHandler) Execute(w http.ResponseWriter, r *http.Request) (int, error) {
-	var requestBody interface{}
-	var bytes []byte
-	if r.Body != nil {
-		bytes, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			return 500, fmt.Errorf("Error reading request body in Execute handler: %v", err)
-		}
-
-		if len(bytes) > 0 {
-			err = json.Unmarshal(bytes, &requestBody)
-			if err != nil {
-				return 500, fmt.Errorf("Error unmarshalling request body in Execute handler: %v", err)
-			}
-		}
-	}
 
 	jwtSigned := r.FormValue("token")
 	if jwtSigned != "" {
-		code, err := rh.ExecuteWithJwt(jwtSigned, bytes, r)
+		fmt.Printf("enter jwt,signed:%v", jwtSigned)
+		code, err := rh.ExecuteWithJwt(jwtSigned, r)
 		if err != nil {
 			return code, err
 		}
 		return 200, nil
 	}
-
 	uuid := r.FormValue("key")
 	if uuid == "" {
 		return 400, fmt.Errorf("Invalid execute url, should have 'token' or 'key'")
@@ -47,7 +30,7 @@ func (rh *RouteHandler) Execute(w http.ResponseWriter, r *http.Request) (int, er
 		return 400, fmt.Errorf("Invalid execute url, url must contain projectId")
 	}
 
-	code, err := rh.ExecuteWithKey(uuid, projectID, bytes, r)
+	code, err := rh.ExecuteWithKey(uuid, projectID, r)
 	if err != nil {
 		return code, err
 	}
@@ -55,7 +38,7 @@ func (rh *RouteHandler) Execute(w http.ResponseWriter, r *http.Request) (int, er
 	return 200, nil
 }
 
-func (rh *RouteHandler) ExecuteWithJwt(jwtSigned string, requestBody interface{}, request interface{}) (int, error) {
+func (rh *RouteHandler) ExecuteWithJwt(jwtSigned string, request interface{}) (int, error) {
 	token, err := jwt.Parse(jwtSigned, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
@@ -98,7 +81,7 @@ func (rh *RouteHandler) ExecuteWithJwt(jwtSigned string, requestBody interface{}
 			return code, err
 		}
 
-		responseCode, err := driver.Execute(claims["config"], apiClient, requestBody, request)
+		responseCode, err := driver.Execute(claims["config"], apiClient, request)
 		if err != nil {
 			return responseCode, fmt.Errorf("Error %v in executing driver for %s", err, driverID)
 		}
@@ -106,7 +89,7 @@ func (rh *RouteHandler) ExecuteWithJwt(jwtSigned string, requestBody interface{}
 	return 200, nil
 }
 
-func (rh *RouteHandler) ExecuteWithKey(uuid string, projectID string, requestBody interface{}, request interface{}) (int, error) {
+func (rh *RouteHandler) ExecuteWithKey(uuid string, projectID string, request interface{}) (int, error) {
 	apiClient, err := rh.ClientFactory.GetClient(projectID)
 	if err != nil {
 		return 500, err
@@ -141,7 +124,7 @@ func (rh *RouteHandler) ExecuteWithKey(uuid string, projectID string, requestBod
 		return 400, fmt.Errorf("Driver config not found")
 	}
 
-	responseCode, err := driver.Execute(driverConfig, apiClient, requestBody, request)
+	responseCode, err := driver.Execute(driverConfig, apiClient, request)
 	if err != nil {
 		return responseCode, fmt.Errorf("Error %v in executing driver for %s", err, driverID)
 	}

--- a/service/execute_handler.go
+++ b/service/execute_handler.go
@@ -13,6 +13,7 @@ import (
 
 func (rh *RouteHandler) Execute(w http.ResponseWriter, r *http.Request) (int, error) {
 	var requestBody interface{}
+	var bytes []byte
 	if r.Body != nil {
 		bytes, err := ioutil.ReadAll(r.Body)
 		if err != nil {
@@ -29,7 +30,7 @@ func (rh *RouteHandler) Execute(w http.ResponseWriter, r *http.Request) (int, er
 
 	jwtSigned := r.FormValue("token")
 	if jwtSigned != "" {
-		code, err := rh.ExecuteWithJwt(jwtSigned, requestBody, r)
+		code, err := rh.ExecuteWithJwt(jwtSigned, bytes, r)
 		if err != nil {
 			return code, err
 		}
@@ -46,7 +47,7 @@ func (rh *RouteHandler) Execute(w http.ResponseWriter, r *http.Request) (int, er
 		return 400, fmt.Errorf("Invalid execute url, url must contain projectId")
 	}
 
-	code, err := rh.ExecuteWithKey(uuid, projectID, requestBody, r)
+	code, err := rh.ExecuteWithKey(uuid, projectID, bytes, r)
 	if err != nil {
 		return code, err
 	}

--- a/service/framework_test.go
+++ b/service/framework_test.go
@@ -67,6 +67,11 @@ func init() {
 	}
 	drivers.Drivers["scaleHost"] = &MockHostDriver{expectedConfigLabel: expectedHostConfigLabel, expectedConfigHostTemplate: expectedHostConfigHostTemplate}
 
+	expectedServiceWebhookTemplate := model.ServiceWebhook{
+		ServiceURL: "http",
+	}
+	drivers.Drivers["serviceWebhook"] = &MockServiceWebhookDriver{expectedConfig: expectedServiceWebhookTemplate}
+
 	privateKey := util.ParsePrivateKey("../testutils/private.pem")
 	publicKey := util.ParsePublicKey("../testutils/public.pem")
 	r = &RouteHandler{

--- a/service/scale_host_test.go
+++ b/service/scale_host_test.go
@@ -487,7 +487,7 @@ type MockHostDriver struct {
 	expectedConfigHostTemplate model.ScaleHost
 }
 
-func (s *MockHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, reqbody interface{}, _ interface{}) (int, error) {
+func (s *MockHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, req interface{}) (int, error) {
 	config := &model.ScaleHost{}
 	err := mapstructure.Decode(conf, config)
 	if err != nil {

--- a/service/scale_host_test.go
+++ b/service/scale_host_test.go
@@ -487,7 +487,7 @@ type MockHostDriver struct {
 	expectedConfigHostTemplate model.ScaleHost
 }
 
-func (s *MockHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, reqbody interface{}) (int, error) {
+func (s *MockHostDriver) Execute(conf interface{}, apiClient *client.RancherClient, reqbody interface{}, _ interface{}) (int, error) {
 	config := &model.ScaleHost{}
 	err := mapstructure.Decode(conf, config)
 	if err != nil {

--- a/service/scale_service_test.go
+++ b/service/scale_service_test.go
@@ -271,7 +271,7 @@ type MockServiceDriver struct {
 	expectedConfig model.ScaleService
 }
 
-func (s *MockServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, payload interface{}) (int, error) {
+func (s *MockServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, payload interface{}, req interface{}) (int, error) {
 	config := &model.ScaleService{}
 	err := mapstructure.Decode(conf, config)
 	if err != nil {

--- a/service/scale_service_test.go
+++ b/service/scale_service_test.go
@@ -271,7 +271,7 @@ type MockServiceDriver struct {
 	expectedConfig model.ScaleService
 }
 
-func (s *MockServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, payload interface{}, req interface{}) (int, error) {
+func (s *MockServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, req interface{}) (int, error) {
 	config := &model.ScaleService{}
 	err := mapstructure.Decode(conf, config)
 	if err != nil {

--- a/service/service_webhook_test.go
+++ b/service/service_webhook_test.go
@@ -1,0 +1,192 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mitchellh/mapstructure"
+	v1client "github.com/rancher/go-rancher/client"
+	"github.com/rancher/go-rancher/v2"
+	"github.com/rancher/webhook-service/drivers"
+	"github.com/rancher/webhook-service/model"
+)
+
+func TestCreateAndUpgdate(t *testing.T) {
+	// Test creating a webhook
+	constructURL := fmt.Sprintf("%s/v1-webhooks/receivers?projectId=1a1", server.URL)
+	jsonStr := []byte(`{"driver":"serviceWebhook","name":"wh-name",
+		"serviceWebhookConfig": {"serviceURL": "http"}}`)
+	request, err := http.NewRequest("POST", constructURL, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler := HandleError(schemas, r.ConstructPayload)
+	handler.ServeHTTP(response, request)
+	if response.Code != 200 {
+		t.Fatalf("StatusCode %d means ConstructPayloadTest failed", response.Code)
+	}
+	resp, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wh := &model.Webhook{}
+
+	if strings.Contains(string(resp), "\\u0026") {
+		t.Fatalf("Bad execute URL, contains escaped `&` character")
+	}
+
+	err = json.Unmarshal(resp, wh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wh.Name != "wh-name" || wh.Driver != "serviceWebhook" || wh.Id != "1" || wh.URL == "" || wh.ServiceWebhookConfig.ServiceURL != "http" {
+		t.Fatalf("Unexpected webhook: %#v", wh)
+	}
+	if !strings.HasSuffix(wh.Links["self"], "/v1-webhooks/receivers/1?projectId=1a1") {
+		t.Fatalf("Bad self URL: %v", wh.Links["self"])
+	}
+
+	// Test getting the created webhook by id
+	byID := fmt.Sprintf("%s/v1-webhooks/receivers/1?projectId=1a1", server.URL)
+	request, err = http.NewRequest("GET", byID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != 200 {
+		t.Fatalf("StatusCode %d means get failed", response.Code)
+	}
+	resp, err = ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wh = &model.Webhook{}
+	err = json.Unmarshal(resp, wh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wh.Name != "wh-name" || wh.Driver != "serviceWebhook" || wh.Id != "1" || wh.URL == "" || wh.ServiceWebhookConfig.ServiceURL != "http" {
+		t.Fatalf("Unexpected webhook: %#v", wh)
+	}
+	if !strings.HasSuffix(wh.Links["self"], "/v1-webhooks/receivers/1?projectId=1a1") {
+		t.Fatalf("Bad self URL: %v", wh.Links["self"])
+	}
+
+	// Test executing the webhook
+	url := wh.URL
+	requestExecute, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response = httptest.NewRecorder()
+	handler = HandleError(schemas, r.Execute)
+	handler.ServeHTTP(response, requestExecute)
+	if response.Code != 200 {
+		t.Errorf("StatusCode %d means execute failed", response.Code)
+	}
+
+	//List webhooks
+	requestList, err := http.NewRequest("GET", constructURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestList.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, requestList)
+	if response.Code != 200 {
+		t.Fatalf("StatusCode %d means get failed", response.Code)
+	}
+	resp, err = ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	whCollection := &model.WebhookCollection{}
+	err = json.Unmarshal(resp, whCollection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(whCollection.Data) != 1 {
+		t.Fatal("Added webhook not listed")
+	}
+	wh = &whCollection.Data[0]
+	if wh.Name != "wh-name" || wh.Driver != "serviceWebhook" || wh.Id != "1" || wh.URL == "" || wh.ServiceWebhookConfig.ServiceURL != "http" {
+		t.Fatalf("Unexpected webhook: %#v", wh)
+	}
+	if !strings.HasSuffix(wh.Links["self"], "/v1-webhooks/receivers/1?projectId=1a1") {
+		t.Fatalf("Bad self URL: %v", wh.Links["self"])
+	}
+
+	//Delete
+	request, err = http.NewRequest("DELETE", byID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != 204 {
+		t.Fatalf("StatusCode %d means delete failed", response.Code)
+	}
+}
+
+type MockServiceWebhookDriver struct {
+	expectedConfig model.ServiceWebhook
+}
+
+func (s *MockServiceWebhookDriver) Execute(conf interface{}, apiClient *client.RancherClient, payload interface{}, req interface{}) (int, error) {
+	config := &model.ServiceWebhook{}
+	requestBody := make(map[string]interface{})
+	request := make(map[string]interface{})
+	err := mapstructure.Decode(conf, config)
+
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("Couldn't unmarshal config: %v", err)
+	}
+	requestBody, ok := payload.(map[string]interface{})
+	if ok {
+	}
+	request, ok = req.(map[string]interface{})
+	if ok {
+	}
+	logrus.Infof("%v, %v", request, requestBody)
+	if config.ServiceURL != s.expectedConfig.ServiceURL {
+		return 500, fmt.Errorf("Tag. Expected %v, Actual %v", s.expectedConfig.ServiceURL, config.ServiceURL)
+	}
+
+	logrus.Infof("Execute of mock upgradeService driver")
+	return 0, nil
+}
+
+func (s *MockServiceWebhookDriver) ValidatePayload(conf interface{}, apiClient *client.RancherClient) (int, error) {
+	_, ok := conf.(model.ServiceWebhook)
+	if !ok {
+		return http.StatusInternalServerError, fmt.Errorf("Can't process config")
+	}
+
+	logrus.Infof("Validate payload of mock serviceWebhook driver")
+	return 0, nil
+}
+
+func (s *MockServiceWebhookDriver) GetDriverConfigResource() interface{} {
+	return model.ServiceWebhook{}
+}
+
+func (s *MockServiceWebhookDriver) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
+	return schema
+}
+
+func (s *MockServiceWebhookDriver) ConvertToConfigAndSetOnWebhook(conf interface{}, webhook *model.Webhook) error {
+	ss := &drivers.ServiceWebhookDriver{}
+	return ss.ConvertToConfigAndSetOnWebhook(conf, webhook)
+}

--- a/service/service_webhook_test.go
+++ b/service/service_webhook_test.go
@@ -144,22 +144,18 @@ type MockServiceWebhookDriver struct {
 	expectedConfig model.ServiceWebhook
 }
 
-func (s *MockServiceWebhookDriver) Execute(conf interface{}, apiClient *client.RancherClient, payload interface{}, req interface{}) (int, error) {
+func (s *MockServiceWebhookDriver) Execute(conf interface{}, apiClient *client.RancherClient, req interface{}) (int, error) {
 	config := &model.ServiceWebhook{}
-	requestBody := make(map[string]interface{})
 	request := make(map[string]interface{})
 	err := mapstructure.Decode(conf, config)
 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("Couldn't unmarshal config: %v", err)
 	}
-	requestBody, ok := payload.(map[string]interface{})
+	request, ok := req.(map[string]interface{})
 	if ok {
 	}
-	request, ok = req.(map[string]interface{})
-	if ok {
-	}
-	logrus.Infof("%v, %v", request, requestBody)
+	logrus.Infof("%v", request)
 	if config.ServiceURL != s.expectedConfig.ServiceURL {
 		return 500, fmt.Errorf("Tag. Expected %v, Actual %v", s.expectedConfig.ServiceURL, config.ServiceURL)
 	}

--- a/service/upgrade_service_test.go
+++ b/service/upgrade_service_test.go
@@ -260,7 +260,7 @@ type MockUpgradeServiceDriver struct {
 	expectedConfig model.ServiceUpgrade
 }
 
-func (s *MockUpgradeServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, payload interface{}, _ interface{}) (int, error) {
+func (s *MockUpgradeServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, request interface{}) (int, error) {
 	config := &model.ServiceUpgrade{}
 	err := mapstructure.Decode(conf, config)
 	if err != nil {

--- a/service/upgrade_service_test.go
+++ b/service/upgrade_service_test.go
@@ -260,7 +260,7 @@ type MockUpgradeServiceDriver struct {
 	expectedConfig model.ServiceUpgrade
 }
 
-func (s *MockUpgradeServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, payload interface{}) (int, error) {
+func (s *MockUpgradeServiceDriver) Execute(conf interface{}, apiClient *client.RancherClient, payload interface{}, _ interface{}) (int, error) {
 	config := &model.ServiceUpgrade{}
 	err := mapstructure.Decode(conf, config)
 	if err != nil {


### PR DESCRIPTION
## Why do we need this kind of driver？
In CI project, We need a mechanism to redirect the webhook request from GitHub into our pipeline-service.
This mechanism needs the following features:

1. Redirect requests from outside of Rancher into our pipeline-service without the authentication of Rancher.
2. We can access the original requests' header/URL/body when the requests are redirected to the pipeline-server. 

## What's this type able to do?

This is a general redirector.
You can set any `serviceURL` you want.
In our CI project, we set the `serviceURL` as `/r/projects/%PROJECTID%/pipeline-server:60080/v1/webhook`.  As you can see, we redirect the webhook to`magic proxy`.

```
type ServiceWebhook struct {
        ServiceURL string `json:"serviceURL,omitempty" mapstructure:"serviceURL"`
	Type       string `json:"type,omitempty" mapstructure:"type"`
}
```

## What did we change?
The biggest change is we pass the `request` instead of `requestBody` down. So that we can access the whole original request in the interface of `Execute`, and transfer to another endpoint. Since we modified the original interface, we can't avoid changing all the original drivers.
```
-	Execute(config interface{}, apiClient *client.RancherClient, requestBody interface{}) (int, error)
+	Execute(config interface{}, apiClient *client.RancherClient, request interface{}) (int, error)
```
