### PR TITLE
Fix aliyun dockerhub issue and support Azure Container Registry

### DIFF
--- a/drivers/service_upgrade.go
+++ b/drivers/service_upgrade.go
@@ -82,24 +82,22 @@ func (s *ServiceUpgradeDriver) Execute(conf interface{}, apiClient *client.Ranch
 		return http.StatusBadRequest, fmt.Errorf("Body should be of type map[string]interface{}")
 	}
 
-	pushedData, ok := requestBody["push_data"]
-	if !ok {
-		return http.StatusBadRequest, fmt.Errorf("Incomplete webhook response provided")
-	}
-
-	pushedTag, ok := pushedData.(map[string]interface{})["tag"].(string)
-	if !ok {
-		return http.StatusBadRequest, fmt.Errorf("Webhook response contains no tag")
-	}
-
-	repository, ok := requestBody["repository"]
-	if !ok {
-		return http.StatusBadRequest, fmt.Errorf("Response provided without repository information")
-	}
-
 	pushedImage := ""
+	pushedTag := ""
 	switch config.PayloadFormat {
 	case "alicloud":
+		pushedData, ok := requestBody["push_data"]
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Incomplete Alicloud Docker Hub webhook response provided")
+		}
+		pushedTag, ok = pushedData.(map[string]interface{})["tag"].(string)
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Alicloud Docker Hub webhook response contains no tag")
+		}
+		repository, ok := requestBody["repository"]
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Alicloud Docker Hub response provided without repository information")
+		}
 		alicloudFullName, fullnameOk := repository.(map[string]interface{})["repo_full_name"].(string)
 		alicloudRegion, regionOk := repository.(map[string]interface{})["region"].(string)
 		if fullnameOk && regionOk {
@@ -112,7 +110,40 @@ func (s *ServiceUpgradeDriver) Execute(conf interface{}, apiClient *client.Ranch
 		} else {
 			return http.StatusBadRequest, fmt.Errorf("Alicloud Docker Hub response provided without image name")
 		}
+	case "azure":
+		pushedData, ok := requestBody["target"]
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Incomplete Azure Container Reigstry webhook response provided")
+		}
+		pushedTag, ok = pushedData.(map[string]interface{})["tag"].(string)
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Azure Container Reigstry webhook response contains no tag")
+		}
+		repository, ok := requestBody["request"]
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Azure Container Reigstry response provided without request information")
+		}
+		azureHost, hostOk := repository.(map[string]interface{})["host"].(string)
+		azureRepo, repoOk := pushedData.(map[string]interface{})["repository"].(string)
+		if hostOk && repoOk {
+			imageName := azureHost + "/" + azureRepo
+			pushedImage = imageName + ":" + pushedTag
+		} else {
+			return http.StatusBadRequest, fmt.Errorf("Azure Container Reigstry response provided without image name")
+		}
 	default:
+		pushedData, ok := requestBody["push_data"]
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Incomplete webhook response provided")
+		}
+		pushedTag, ok = pushedData.(map[string]interface{})["tag"].(string)
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Webhook response contains no tag")
+		}
+		repository, ok := requestBody["repository"]
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("Response provided without repository information")
+		}
 		imageName, ok := repository.(map[string]interface{})["repo_name"].(string)
 		if !ok {
 			return http.StatusBadRequest, fmt.Errorf("Response provided without image name")
@@ -270,7 +301,7 @@ func (s *ServiceUpgradeDriver) GetDriverConfigResource() interface{} {
 }
 
 func (s *ServiceUpgradeDriver) CustomizeSchema(schema *v1client.Schema) *v1client.Schema {
-	options := []string{"dockerhub", "alicloud"}
+	options := []string{"dockerhub", "alicloud", "azure"}
 	minValue := int64(1)
 
 	payloadFormat := schema.ResourceFields["payloadFormat"]

--- a/drivers/service_upgrade.go
+++ b/drivers/service_upgrade.go
@@ -103,7 +103,11 @@ func (s *ServiceUpgradeDriver) Execute(conf interface{}, apiClient *client.Ranch
 		alicloudFullName, fullnameOk := repository.(map[string]interface{})["repo_full_name"].(string)
 		alicloudRegion, regionOk := repository.(map[string]interface{})["region"].(string)
 		if fullnameOk && regionOk {
-			imageName := "registry." + alicloudRegion + ".aliyuncs.com/" + alicloudFullName
+			addressType := config.AddressType
+			if addressType == "" {
+				addressType = "registry"
+			}
+			imageName := addressType + "." + alicloudRegion + ".aliyuncs.com/" + alicloudFullName
 			pushedImage = imageName + ":" + pushedTag
 		} else {
 			return http.StatusBadRequest, fmt.Errorf("Alicloud Docker Hub response provided without image name")
@@ -274,6 +278,13 @@ func (s *ServiceUpgradeDriver) CustomizeSchema(schema *v1client.Schema) *v1clien
 	payloadFormat.Options = options
 	payloadFormat.Default = options[0]
 	schema.ResourceFields["payloadFormat"] = payloadFormat
+
+	addressTypes := []string{"registry", "registry-internal", "registry-vpc"}
+	addressType := schema.ResourceFields["addressType"]
+	addressType.Type = "enum"
+	addressType.Options = addressTypes
+	addressType.Default = addressTypes[0]
+	schema.ResourceFields["addressType"] = addressType
 
 	batchSize := schema.ResourceFields["batchSize"]
 	batchSize.Default = 1

--- a/model/driver_model.go
+++ b/model/driver_model.go
@@ -15,6 +15,7 @@ type ServiceUpgrade struct {
 	ServiceSelector map[string]string `json:"serviceSelector,omitempty" mapstructure:"serviceSelector"`
 	Tag             string            `json:"tag,omitempty" mapstructure:"tag"`
 	PayloadFormat   string            `json:"payloadFormat,omitempty" mapstructure:"payloadFormat"`
+	AddressType     string            `json:"addressType,omitempty" mapstructure:"addressType"`
 	BatchSize       int64             `json:"batchSize,omitempty" mapstructure:"batchSize"`
 	IntervalMillis  int64             `json:"intervalMillis,omitempty" mapstructure:"intervalMillis"`
 	StartFirst      bool              `json:"startFirst,omitempty" mapstructure:"startFirst"`


### PR DESCRIPTION
There are three address types for one image in aliyun dockerhub.
Now we only supports the public one. We need a new field to let user specify it.

`registry`.cn-hangzhou.aliyuncs.com/logan/test
`registry-internal`.cn-hangzhou.aliyuncs.com/logan/test
`registry-vpc`.cn-hangzhou.aliyuncs.com/logan/test

https://github.com/rancher/rancher/issues/10654


Payload for Azure Container Registry
https://github.com/rancher/rancher/issues/10639
```
{
  "id": "cb8c3971-9adc-488b-bdd8-43cbb4974ff5",
  "timestamp": "2017-11-17T16:52:01.343145347Z",
  "action": "push",
  "target": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "size": 524,
    "digest": "sha256:80f0d5c8786bb9e621a45ece0db56d11cdc624ad20da9fe62e9d25490f331d7d",
    "length": 524,
    "repository": "hello-world",
    "tag": "v1"
  },
  "request": {
    "id": "3cbb6949-7549-4fa1-86cd-a6d5451dffc7",
    "host": "myregistry.azurecr.io",
    "method": "PUT",
    "useragent": "docker/17.09.0-ce go/go1.8.3 git-commit/afdb6d4 kernel/4.10.0-27-generic os/linux arch/amd64 UpstreamClient(Docker-Client/17.09.0-ce \\(linux\\))"
  }
}
```